### PR TITLE
feat: add Workspace.select() convenience method (#22)

### DIFF
--- a/src/spectrik/workspace.py
+++ b/src/spectrik/workspace.py
@@ -183,6 +183,12 @@ class Workspace[P: Project](Mapping[str, P]):
         """Return projects matching the given names, preserving input order."""
         return [self._project_refs[n].resolve(self) for n in names if n in self._project_refs]  # type: ignore[misc]
 
+    def select(self, names: Iterable[str] | None = None) -> list[P]:
+        """Return filtered projects if *names* is given, otherwise all projects."""
+        if names:
+            return self.filter(names)
+        return list(self.values())
+
     def __repr__(self) -> str:
         type_name = self._project_type.__name__
         bp_count = len(self._blueprint_refs)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -209,6 +209,42 @@ class TestWorkspaceMapping:
         ws.add(ProjectRef(name="a", use=[], ops=[], description="alpha"))
         assert ws.filter([]) == []
 
+    def test_select_with_names(self):
+        ws = Workspace()
+        ws.add(
+            ProjectRef(name="a", use=[], ops=[], description="alpha"),
+            ProjectRef(name="b", use=[], ops=[], description="beta"),
+            ProjectRef(name="c", use=[], ops=[], description="gamma"),
+        )
+        result = ws.select(["a", "c"])
+        assert len(result) == 2
+        assert result[0].name == "a"
+        assert result[1].name == "c"
+
+    def test_select_without_names(self):
+        ws = Workspace()
+        ws.add(
+            ProjectRef(name="a", use=[], ops=[], description="alpha"),
+            ProjectRef(name="b", use=[], ops=[], description="beta"),
+        )
+        result = ws.select()
+        assert len(result) == 2
+
+    def test_select_with_none(self):
+        ws = Workspace()
+        ws.add(
+            ProjectRef(name="a", use=[], ops=[], description="alpha"),
+            ProjectRef(name="b", use=[], ops=[], description="beta"),
+        )
+        result = ws.select(None)
+        assert len(result) == 2
+
+    def test_select_with_empty_list(self):
+        ws = Workspace()
+        ws.add(ProjectRef(name="a", use=[], ops=[], description="alpha"))
+        result = ws.select([])
+        assert len(result) == 1
+
     def test_custom_project_type(self):
         class Custom(Project):
             repo: str = ""


### PR DESCRIPTION
## Summary

- Add `Workspace.select(names=None)` that returns all projects when `names` is empty/None, or filtered projects when names are provided
- Eliminates the repeated 2-line conditional pattern across all downstream consumers

Closes #22

## Usage

```python
# Before
if projects:
    selected = workspace.filter(projects)
else:
    selected = list(workspace.values())

# After
selected = workspace.select(projects)
```

## Test plan

- [x] `select(["a", "c"])` returns filtered projects in order
- [x] `select()` with no args returns all projects
- [x] `select(None)` returns all projects
- [x] `select([])` returns all projects (empty list = no filter)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)