### PR TITLE
feat(registry): include source file in unregistered spec errors

### DIFF
--- a/src/spectrik/hcl.py
+++ b/src/spectrik/hcl.py
@@ -33,37 +33,57 @@ def _iter_blocks(
         yield from block.items()
 
 
-def _parse_op(strategy: str, spec_name: str, attrs: dict[str, Any]) -> OperationRef:
+def _parse_op(
+    strategy: str,
+    spec_name: str,
+    attrs: dict[str, Any],
+    *,
+    source: Path | None = None,
+) -> OperationRef:
     """Create a single OperationRef from HCL strategy block data."""
-    return OperationRef(name=spec_name, strategy=strategy, attrs=dict(attrs))
+    return OperationRef(name=spec_name, strategy=strategy, attrs=dict(attrs), source=source)
 
 
-def _parse_ops(block_data: dict[str, Any]) -> list[OperationRef]:
+def _parse_ops(
+    block_data: dict[str, Any],
+    *,
+    source: Path | None = None,
+) -> list[OperationRef]:
     """Translate HCL strategy blocks into OperationRefs."""
     return [
-        _parse_op(strategy, spec_name, attrs)
+        _parse_op(strategy, spec_name, attrs, source=source)
         for strategy in _STRATEGY_NAMES
         for spec_name, attrs in _iter_blocks(block_data, strategy)
     ]
 
 
-def _parse_blueprint(name: str, data: dict[str, Any]) -> BlueprintRef:
+def _parse_blueprint(
+    name: str,
+    data: dict[str, Any],
+    *,
+    source: Path | None = None,
+) -> BlueprintRef:
     """Translate an HCL blueprint block into a BlueprintRef."""
     return BlueprintRef(
         name=name,
         includes=data.get("include", []),
-        ops=_parse_ops(data),
+        ops=_parse_ops(data, source=source),
         description=data.get("description", ""),
     )
 
 
-def _parse_project(name: str, data: dict[str, Any]) -> ProjectRef:
+def _parse_project(
+    name: str,
+    data: dict[str, Any],
+    *,
+    source: Path | None = None,
+) -> ProjectRef:
     """Translate an HCL project block into a ProjectRef."""
     skip_keys = {"use", "include", "description"} | _STRATEGY_NAMES
     return ProjectRef(
         name=name,
         use=data.get("use", []),
-        ops=_parse_ops(data),
+        ops=_parse_ops(data, source=source),
         description=data.get("description", ""),
         attrs={k: v for k, v in data.items() if k not in skip_keys},
     )
@@ -117,12 +137,12 @@ def parse(
         match block_type:
             case "blueprint":
                 refs.extend(
-                    _parse_blueprint(name, block_data)
+                    _parse_blueprint(name, block_data, source=file)
                     for name, block_data in _iter_blocks(data, block_type)
                 )
             case "project":
                 refs.extend(
-                    _parse_project(name, block_data)
+                    _parse_project(name, block_data, source=file)
                     for name, block_data in _iter_blocks(data, block_type)
                 )
             case _:

--- a/src/spectrik/workspace.py
+++ b/src/spectrik/workspace.py
@@ -6,6 +6,7 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Self, overload
 
 from .blueprints import Blueprint
@@ -40,10 +41,15 @@ class OperationRef(WorkspaceRef):
     strategy: str
     attrs: dict[str, Any]
     label: str | None = None
+    source: Path | None = None
 
     def resolve(self, workspace: Workspace) -> SpecOp:
         if self.name not in _spec_registry:
-            raise ValueError(f"Unknown spec type: '{self.name}'")
+            msg = f"Unknown spec type: '{self.name}'"
+            if self.source is not None:
+                msg += f" in {self.source}"
+            msg += " — ensure the module registering this spec is imported"
+            raise ValueError(msg)
         if self.strategy not in _STRATEGY_MAP:
             raise ValueError(f"Unknown strategy: '{self.strategy}'")
         spec_cls = _spec_registry[self.name]

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -63,7 +63,22 @@ class TestOperationRef:
     def test_resolve_unknown_spec_raises(self):
         ref = OperationRef(name="nonexistent", strategy="ensure", attrs={})
         ws = Workspace()
-        with pytest.raises(ValueError, match="Unknown spec type"):
+        with pytest.raises(ValueError, match="Unknown spec type: 'nonexistent'"):
+            ref.resolve(ws)
+
+    def test_resolve_unknown_spec_includes_source(self):
+        from pathlib import Path
+
+        source = Path("/tmp/test-config.hcl")
+        ref = OperationRef(name="nonexistent", strategy="ensure", attrs={}, source=source)
+        ws = Workspace()
+        with pytest.raises(ValueError, match="in /tmp/test-config.hcl"):
+            ref.resolve(ws)
+
+    def test_resolve_unknown_spec_suggests_import(self):
+        ref = OperationRef(name="nonexistent", strategy="ensure", attrs={})
+        ws = Workspace()
+        with pytest.raises(ValueError, match="ensure the module registering this spec is imported"):
             ref.resolve(ws)
 
     def test_resolve_unknown_strategy_raises(self):


### PR DESCRIPTION
## Summary

- Threads the HCL source file path through the parsing pipeline into `OperationRef`
- Enriches the `ValueError` raised for unregistered spec types with the source file path and an actionable hint
- Error now reads: `Unknown spec type: 'foo' in /path/to/config.hcl — ensure the module registering this spec is imported`

Closes #23 (error message portion — discovery mechanism deferred to a future issue)

## Test plan

- [x] Existing test updated to match refined error message
- [x] New test: error includes source file path when set
- [x] New test: error includes import hint
- [x] `just preflight` passes clean (197 tests, all hooks green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)