### PR TITLE
chore: deprecate Workspace.filter() in favor of select()

### DIFF
--- a/src/spectrik/workspace.py
+++ b/src/spectrik/workspace.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass, field
@@ -189,7 +190,16 @@ class Workspace(Mapping[str, Project]):
         return self._project_refs[name].resolve(self)
 
     def filter(self, names: Iterable[str]) -> list[Project]:
-        """Return projects matching the given names, preserving input order."""
+        """Return projects matching the given names, preserving input order.
+
+        .. deprecated::
+            Use :meth:`select` instead.
+        """
+        warnings.warn(
+            "filter() is deprecated, use select() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.select(names=names)
 
     def select(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 import pytest
 
 from spectrik.context import Context
@@ -183,7 +185,12 @@ class TestWorkspaceMapping:
             ProjectRef(name="b", use=[], ops=[], description="beta"),
             ProjectRef(name="c", use=[], ops=[], description="gamma"),
         )
-        result = ws.filter(["a", "c"])
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = ws.filter(["a", "c"])
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "select()" in str(w[0].message)
         assert len(result) == 2
         assert result[0].name == "a"
         assert result[1].name == "c"
@@ -191,13 +198,21 @@ class TestWorkspaceMapping:
     def test_filter_skips_missing(self):
         ws = Workspace()
         ws.add(ProjectRef(name="a", use=[], ops=[], description="alpha"))
-        result = ws.filter(["a", "missing"])
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = ws.filter(["a", "missing"])
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
         assert len(result) == 1
 
     def test_filter_empty_names(self):
         ws = Workspace()
         ws.add(ProjectRef(name="a", use=[], ops=[], description="alpha"))
-        assert ws.filter([]) == []
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            assert ws.filter([]) == []
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
 
     def test_select_with_names(self):
         ws = Workspace()


### PR DESCRIPTION
## Summary
- Mark `Workspace.filter()` as deprecated with a `DeprecationWarning` pointing users to `select()`
- Update existing filter tests to assert the deprecation warning is emitted

## Test plan
- [x] All 238 existing tests pass
- [x] Filter tests verify `DeprecationWarning` is raised with correct message

🤖 Generated with [Claude Code](https://claude.com/claude-code)