### PR TITLE
fix(hcl): handle python-hcl2 v8 comment metadata (#72)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 license = "MIT"
 dependencies = [
     "pydantic>=2.13.3",
-    "python-hcl2>=8.1.2",
+    "python-hcl2>=8.1.2,<9",
 ]
 
 [dependency-groups]

--- a/src/spectrik/hcl.py
+++ b/src/spectrik/hcl.py
@@ -19,6 +19,7 @@ _STRATEGY_NAMES = frozenset(("present", "ensure", "absent"))
 _SERIALIZATION_OPTS = SerializationOptions(
     strip_string_quotes=True,
     explicit_blocks=False,
+    with_comments=False,
 )
 
 
@@ -142,6 +143,8 @@ def parse(
     refs: list[WorkspaceRef] = []
 
     for block_type in data:
+        if block_type.startswith("__") and block_type.endswith("__"):
+            continue
         if block_type == "blueprint":
             refs.extend(
                 _parse_blueprint(name, block_data, source=file)

--- a/tests/test_hcl.py
+++ b/tests/test_hcl.py
@@ -123,6 +123,31 @@ class TestLoad:
         result = load(tmp_path / "test.hcl", context={})
         assert result["project"][0]["p"]["description"] == "plain"
 
+    def test_load_strips_comment_metadata(self, tmp_path):
+        """python-hcl2 v8 emits __comments__ keys by default; loader must drop them."""
+        _write_hcl(
+            tmp_path,
+            ".",
+            "test.hcl",
+            """
+            # leading hash comment
+            // leading slash comment
+            /* block comment */
+            blueprint "base" {
+                # inside-block comment
+                ensure "widget" {
+                    color = "red"  # trailing inline
+                }
+            }
+        """,
+        )
+        result = load(tmp_path / "test.hcl")
+        assert "__comments__" not in result
+        assert "__inline_comments__" not in result
+        for key in result:
+            assert not key.startswith("__")
+        assert "blueprint" in result
+
     def test_load_undefined_var_raises_with_filepath(self, tmp_path):
         _write_hcl(
             tmp_path,
@@ -435,6 +460,38 @@ class TestParse:
         ref = refs[0]
         assert isinstance(ref, BlueprintRef)
         assert ref.includes == ["base"]
+
+    def test_parse_with_comments(self, tmp_path):
+        """Regression for #72: HCL comments must not break parse()."""
+        _write_hcl(
+            tmp_path,
+            ".",
+            "test.hcl",
+            """
+            # top-level hash comment
+            // top-level slash comment
+            /* top-level block comment */
+            blueprint "base" {
+                # comment inside blueprint
+                ensure "widget" {
+                    // comment inside operation
+                    color = "red"
+                }
+            }
+            project "myproj" {
+                # comment inside project
+                description = "A test project"  // trailing comment
+            }
+        """,
+        )
+        refs = parse(tmp_path / "test.hcl")
+        assert len(refs) == 2
+        bp_refs = [r for r in refs if isinstance(r, BlueprintRef)]
+        proj_refs = [r for r in refs if isinstance(r, ProjectRef)]
+        assert len(bp_refs) == 1
+        assert len(proj_refs) == 1
+        assert bp_refs[0].name == "base"
+        assert proj_refs[0].description == "A test project"
 
     def test_parse_multiple_strategies(self, tmp_path):
         _write_hcl(

--- a/uv.lock
+++ b/uv.lock
@@ -459,7 +459,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pydantic", specifier = ">=2.13.3" },
-    { name = "python-hcl2", specifier = ">=8.1.2" },
+    { name = "python-hcl2", specifier = ">=8.1.2,<9" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Closes #72.

## Summary
- Pass `with_comments=False` to `hcl2.loads()` so `__comments__` / `__inline_comments__` keys are never emitted.
- Defensively skip any `__*__` meta keys in `parse()` so future hcl2 metadata additions don't break consumers.
- Tighten the dep bound to `python-hcl2>=8.1.2,<9` for reproducible installs.
- Add regression tests covering `#`, `//`, and `/* */` comments at top-level, inside blocks, and as trailing inline comments.

## Test plan
- [x] `just preflight` — 240 passed, ruff/pyright clean
- [x] New tests fail without the fix and pass with it