### PR TITLE
fix(hcl): unwrap heredoc values to body strings

### DIFF
--- a/src/spectrik/hcl.py
+++ b/src/spectrik/hcl.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+import re
+import textwrap
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -21,6 +23,30 @@ _SERIALIZATION_OPTS = SerializationOptions(
     explicit_blocks=False,
     with_comments=False,
 )
+
+# python-hcl2 emits heredoc values as raw `<<DELIM\n...\nDELIM` tokens when
+# `preserve_heredocs` is enabled (its default). We post-process to unwrap them.
+_HEREDOC_RE = re.compile(r"\A<<(-?)([a-zA-Z][a-zA-Z0-9._-]*)\n([\s\S]*)\2\Z")
+
+
+def _unwrap_heredoc(value: str) -> str:
+    match = _HEREDOC_RE.match(value)
+    if match is None:
+        return value
+    trim, _delim, body = match.groups()
+    if trim:
+        body = textwrap.dedent(body)
+    return body
+
+
+def _unwrap_heredocs(data: Any) -> Any:
+    if isinstance(data, dict):
+        return {k: _unwrap_heredocs(v) for k, v in data.items()}
+    if isinstance(data, list):
+        return [_unwrap_heredocs(v) for v in data]
+    if isinstance(data, str):
+        return _unwrap_heredoc(data)
+    return data
 
 
 def _iter_blocks(
@@ -200,6 +226,8 @@ def load(
     except Exception as exc:
         logger.error("Could not load file: %s", file, exc_info=exc)
         raise ValueError(f"{file}: {exc}") from exc
+
+    data = _unwrap_heredocs(data)
 
     base_context = context or {}
 

--- a/tests/test_hcl.py
+++ b/tests/test_hcl.py
@@ -148,6 +148,59 @@ class TestLoad:
             assert not key.startswith("__")
         assert "blueprint" in result
 
+    def test_load_heredoc_returns_unwrapped_body(self, tmp_path):
+        """Heredoc values should be unwrapped to their body, not raw <<EOT...EOT tokens."""
+        _write_hcl(
+            tmp_path,
+            ".",
+            "test.hcl",
+            """
+            ensure "widget" {
+                template = <<EOT
+hello world
+line2
+EOT
+            }
+        """,
+        )
+        result = load(tmp_path / "test.hcl")
+        assert result["ensure"][0]["widget"]["template"] == "hello world\nline2\n"
+
+    def test_load_heredoc_indented_dedents_body(self, tmp_path):
+        """`<<-` heredocs should be dedented per the HCL spec."""
+        _write_hcl(
+            tmp_path,
+            ".",
+            "test.hcl",
+            """
+            ensure "widget" {
+                template = <<-EOT
+                    hello world
+                    line2
+                EOT
+            }
+        """,
+        )
+        result = load(tmp_path / "test.hcl")
+        assert result["ensure"][0]["widget"]["template"] == "hello world\nline2\n"
+
+    def test_load_heredoc_with_interpolation(self, tmp_path):
+        """Heredoc bodies should still participate in `${...}` interpolation."""
+        _write_hcl(
+            tmp_path,
+            ".",
+            "test.hcl",
+            """
+            ensure "widget" {
+                template = <<-EOT
+                    hello ${name}
+                EOT
+            }
+        """,
+        )
+        result = load(tmp_path / "test.hcl", context={"name": "world"})
+        assert result["ensure"][0]["widget"]["template"] == "hello world\n"
+
     def test_load_undefined_var_raises_with_filepath(self, tmp_path):
         _write_hcl(
             tmp_path,


### PR DESCRIPTION
## Summary
- Fixes #75 — heredoc attribute values were flowing through as raw `<<EOT...EOT` tokens because python-hcl2 v8 defaults `preserve_heredocs=True`.
- Adds a recursive post-processor (`_unwrap_heredocs`) that runs immediately after `hcl2.loads`, before variable resolution, so `${...}` interpolation still works inside heredoc bodies. `<<-` heredocs are dedented per the HCL spec.
- No coverage existed for heredoc syntax in any HCL fixture — added three regression tests in `TestLoad`.

## Test plan
- [x] `just preflight` (243 passed, pre-commit clean)
- [x] New tests fail before fix, pass after
- [x] Existing test suite unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)